### PR TITLE
remove capitalize function from dorty-pro-deti page

### DIFF
--- a/source/dorty-pro-deti.html.slim
+++ b/source/dorty-pro-deti.html.slim
@@ -27,5 +27,5 @@ description: Cukrářství Kostelec u Zlína nabízí široký sortiment svatebn
 
       .col-md-6.col-lg-4.mb-3
 
-        = link_to "../images/dorty-pro-deti/#{img.split('/').last}", class: 'lightbox', title: img.split('/').last().gsub('-', ' ').sub('.jpg','').capitalize
-            = image_tag "dorty-pro-deti/#{img.split('/').last}", class: 'img-fluid', alt: img.split('/').last().gsub('-', ' ').sub('.jpg','').capitalize
+        = link_to "../images/dorty-pro-deti/#{img.split('/').last}", class: 'lightbox', title: img.split('/').last().gsub('-', ' ').sub('.jpg','')
+            = image_tag "dorty-pro-deti/#{img.split('/').last}", class: 'img-fluid', alt: img.split('/').last().gsub('-', ' ').sub('.jpg','')


### PR DESCRIPTION
by removing capitalize function is is possible to have image names displayed as Pepa Pig instead of Pepa pig